### PR TITLE
Remove non valid check.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,9 +19,7 @@ include secrets/env.$(NRO)
 export $(shell sed 's/=.*//' secrets/env.$(NRO))
 endif
 
-ifneq ($(wildcard secrets/service-accounts/$(NRO).json),)
 SERVICE_ACCOUNT_NAME ?= $(shell cat SERVICE_ACCOUNT_NAME)
-endif
 
 # If the first argument is "run"...
 ifeq (run,$(firstword $(MAKECMDGOALS)))


### PR DESCRIPTION
The service account json file does not necessarily have the name NRO.json, but the SERVICE_ACCOUNT_NAME.json
Since the SERVICE_ACCOUNT_NAME can be different from the NRO the check only confuses things and does not help at all. 
