### PR TITLE
PLANET-5443 Add staging rollback workflow

### DIFF
--- a/templates/nro/.circleci/config-header.yml.tmpl
+++ b/templates/nro/.circleci/config-header.yml.tmpl
@@ -6,7 +6,7 @@ parameters:
   release_stage:
     type: enum
     default: "staging"
-    enum: ["staging", "production"]
+    enum: ["staging", "production", "rollback"]
 {{- end }}
 
 defaults: &defaults

--- a/templates/nro/.circleci/config.yml.tmpl
+++ b/templates/nro/.circleci/config.yml.tmpl
@@ -165,7 +165,7 @@ job_definitions:
       - attach_workspace:
           at: /tmp/workspace
       - run: activate-gcloud-account.sh
-      - run: BUILD_TAG=build-$(cat /tmp/workspace/var/circle-build-num) make -j2 deploy
+      - run: BUILD_TAG=build-$(cat /tmp/workspace/var/circle-build-num) make deploy
       - when:
           condition: << parameters.notify >>
           steps:
@@ -173,6 +173,16 @@ job_definitions:
             - slack/status:
                 channel: C015MQGG3KQ
                 webhook: ${SLACK_NRO_WEBHOOK}
+
+{{- if isTrue .Env.MAKE_RELEASE }}
+  rollback_steps: &rollback_steps
+    working_directory: ~/
+    steps:
+     - attach_workspace:
+         at: /tmp/workspace
+     - run: activate-gcloud-account.sh
+     - run: make rollback
+{{- end }}
 
 jobs:
   visualtests-reference-develop:
@@ -250,6 +260,13 @@ jobs:
     steps:
       - checkout
       - run: merge-develop.sh
+
+  rollback-staging:
+    <<: *defaults
+    environment:
+      <<: *common_environment
+      <<: *release_environment
+    <<: *rollback_steps
 {{- end }}
 
 {{- if isTrue .Env.MAKE_MASTER }}
@@ -483,6 +500,20 @@ workflows:
           requires:
             - hold-production
 {{- end }}
+{{- end }}
+
+{{- if isTrue .Env.MAKE_RELEASE }}
+  rollback-staging:
+    when:
+      equal: [ "rollback", << pipeline.parameters.release_stage >> ]
+    jobs:
+      - hold-rollback:
+          <<: *staging_common
+          type: approval
+      - rollback-staging:
+          <<: *staging_common
+          requires:
+            - hold-rollback
 {{- end }}
 
 {{- if isTrue .Env.MAKE_MASTER }}


### PR DESCRIPTION
This also removes j2 from deploy command, since deploy target on builder is now split in more jobs that can't run in parallel.

**So the order of PRs**
1. First on Backstop, added the script to trigger the new `rollback` workflow when visual regression tests fail after a deployment on staging: greenpeace/planet4-backstop#4
2. Then on builder, making the necessary adjustments on the `Makefile` to introduce a new `rollback` target: greenpeace/planet4-builder#53
3. This one, that adds the new workflow to our CI templates.

**Testing example**
I pushed this new configuration to `cidev` instance, so:
1. A [new staging deployment](https://app.circleci.com/pipelines/github/greenpeace/planet4-cidev/470/workflows/99b5d140-1c7f-47ee-ae75-194b1fa377e3), where tests fail.
2. The `visualtests-compare` job [triggers a request to CircleCI API](https://app.circleci.com/pipelines/github/greenpeace/planet4-cidev/470/workflows/99b5d140-1c7f-47ee-ae75-194b1fa377e3/jobs/1341).
3. The `rollback-staging` [workflow is triggered](https://app.circleci.com/pipelines/github/greenpeace/planet4-cidev/473/workflows/aa5164e8-5911-437a-83a7-6c76af1e7a8c) waiting for approval.
