### PR TITLE
PLANET-5409 Build 1 image for stag and prod

### DIFF
--- a/bin/update_configs.sh
+++ b/bin/update_configs.sh
@@ -18,15 +18,18 @@ config_header=./templates/nro/.circleci/config-header.yml.tmpl
 
 function update_site() {
   local repo="planet4-$1"
+  local repo_dir="tmp/update/$repo"
   local is_prod=${2:-false}
   local tmp_config_file="./tmpConfig-$1"
   local generator_hash
   generator_hash="$(git rev-parse HEAD)"
   local generator_link="https://github.com/greenpeace/planet4-nro-generator/blob/${generator_hash}/templates/nro/.circleci/config.yml.tmpl"
 
-  git clone git@github.com:greenpeace/"${repo}".git --single-branch --branch develop --quiet
+  rm -rf "$repo_dir"
 
-  if [ ! -f "${repo}"/.circleci/artifacts.yml ]
+  git clone --single-branch --branch develop --quiet git@github.com:greenpeace/"${repo}".git "$repo_dir"
+
+  if [ ! -f "${repo_dir}"/.circleci/artifacts.yml ]
   then
       echo "${repo} - DOES NOT have an artifacts file. Cannot generate new configuration"
   else
@@ -38,19 +41,19 @@ function update_site() {
       MAKE_MASTER=$is_prod \
       dockerize \
       -template "./templates/nro/.circleci/config.yml.tmpl:${tmp_config_file}" \
-      -template ${config_header}:"${repo}/config_header.yml"
+      -template ${config_header}:"${repo_dir}/config_header.yml"
 
-      cat "${repo}/config_header.yml" "${repo}/.circleci/artifacts.yml" "${tmp_config_file}" > "${repo}/.circleci/config.yml"
+      cat "${repo_dir}/config_header.yml" "${repo_dir}/.circleci/artifacts.yml" "${tmp_config_file}" > "${repo_dir}/.circleci/config.yml"
 
-      if git -C "${repo}" diff --quiet
+      if git -C "${repo_dir}" diff --quiet
       then
           echo "${repo} - No changes needed"
       else
           # If specified push the updated config to the repos.
           if [ "$should_push" = true ]
           then
-            git -C "${repo}" commit -m "New CircleCI config" -m "Ref: ${generator_link}" .circleci/config.yml
-            git -C "${repo}" push
+            git -C "${repo_dir}" commit -m "New CircleCI config" -m "Ref: ${generator_link}" .circleci/config.yml
+            git -C "${repo_dir}" push
 
             echo "${repo} - Generated and pushed new configuration"
           fi
@@ -62,9 +65,9 @@ function update_site() {
   if [ "$should_push" = true ]
   then
     echo "${repo} - Removing git repo."
-    rm -rf "${repo}"
+    rm -rf "${repo_dir}"
   else
-    echo "${repo} - Dry run, preserving git repo."
+    echo "${repo} - Dry run, preserving git repo at ${repo_dir}."
   fi
 
 }

--- a/bin/update_configs.sh
+++ b/bin/update_configs.sh
@@ -27,7 +27,7 @@ function update_site() {
 
   rm -rf "$repo_dir"
 
-  git clone --single-branch --branch develop --quiet git@github.com:greenpeace/"${repo}".git "$repo_dir"
+  git clone --branch develop --quiet git@github.com:greenpeace/"${repo}".git "$repo_dir"
 
   if [ ! -f "${repo_dir}"/.circleci/artifacts.yml ]
   then

--- a/templates/nro/.circleci/config-header.yml.tmpl
+++ b/templates/nro/.circleci/config-header.yml.tmpl
@@ -5,8 +5,8 @@ version: 2.1
 parameters:
   release_stage:
     type: enum
-    default: "staging"
-    enum: ["staging", "production", "rollback"]
+    default: "release"
+    enum: ["release", "rollback"]
 {{- end }}
 
 defaults: &defaults

--- a/templates/nro/.circleci/config-header.yml.tmpl
+++ b/templates/nro/.circleci/config-header.yml.tmpl
@@ -1,14 +1,6 @@
 ---
 version: 2.1
 
-{{- if isTrue .Env.MAKE_RELEASE }}
-parameters:
-  release_stage:
-    type: enum
-    default: "release"
-    enum: ["release", "rollback"]
-{{- end }}
-
 defaults: &defaults
   docker:
     - image: greenpeaceinternational/p4-builder:latest

--- a/templates/nro/.circleci/config.yml.tmpl
+++ b/templates/nro/.circleci/config.yml.tmpl
@@ -170,11 +170,34 @@ job_definitions:
       notify:
         type: boolean
         default: false
+      is_prod:
+        type: boolean
+        default: false
     steps:
       - attach_workspace:
           at: /tmp/workspace
       - run: activate-gcloud-account.sh
       - run: BUILD_TAG=build-$(cat /tmp/workspace/var/circle-build-num) make deploy
+      - when:
+          condition: << parameters.is_prod >>
+          steps:
+            - run:
+                name: Initiate finish-staging (approve rollback but it won't really)
+                command: |
+                  url="https://circleci.com/api/v2/workflow/$CIRCLE_WORKFLOW_ID/job"
+
+                  # Get workflow details
+                  workflow=$(curl -s -u "${CIRCLE_TOKEN}": -X GET --header "Content-Type: application/json" "$url")
+                  # Get approval job id
+                  job_id=$(echo "$workflow" | jq -r '.items[] | select(.name=="rollback-staging") | .approval_request_id ')
+
+                  echo "Finishing staging."
+                  echo "Job ID: ${job_id}"
+                  curl \
+                    --header "Content-Type: application/json" \
+                    -u "${CIRCLE_TOKEN}:" \
+                    -X POST \
+                    "https://circleci.com/api/v2/workflow/${CIRCLE_WORKFLOW_ID}/approve/${job_id}"
       - when:
           condition: << parameters.notify >>
           steps:
@@ -184,13 +207,26 @@ job_definitions:
                 webhook: ${SLACK_NRO_WEBHOOK}
 
 {{- if isTrue .Env.MAKE_RELEASE }}
-  rollback_steps: &rollback_steps
+  finish_staging_steps: &finish_staging_steps
     working_directory: ~/
     steps:
      - attach_workspace:
          at: /tmp/workspace
      - run: activate-gcloud-account.sh
-     - run: make rollback
+     - run:
+         name: Get hold-production status
+         command: |
+           url="https://circleci.com/api/v2/workflow/$CIRCLE_WORKFLOW_ID/job"
+           workflow=$(curl -s -u "${CIRCLE_TOKEN}": -X GET --header "Content-Type: application/json" "$url")
+           echo "$workflow" | jq -r '.items[] | select(.name=="hold-production") | .status ' >/tmp/workspace/prod_status
+     - run:
+         name: Rollback if production wasn't approved
+         command: |
+           if [ $(cat /tmp/workspace/prod_status) == 'success' ]; then
+             echo "No need to rollback, production deploy was initiated so staging should stay at this version."
+             exit 0;
+           fi
+           make rollback
 {{- end }}
 
 jobs:
@@ -270,12 +306,12 @@ jobs:
       - checkout
       - run: merge-develop.sh
 
-  rollback-staging:
+  finish-staging:
     <<: *defaults
     environment:
       <<: *common_environment
       <<: *release_environment
-    <<: *rollback_steps
+    <<: *finish_staging_steps
 {{- end }}
 
 {{- if isTrue .Env.MAKE_MASTER }}
@@ -443,8 +479,6 @@ workflows:
 
 {{- if isTrue .Env.MAKE_RELEASE }}
   release:
-    when:
-      equal: [ "release", << pipeline.parameters.release_stage >> ]
     jobs:
       - visualtests-reference:
           <<: *on_release_tag
@@ -464,6 +498,15 @@ workflows:
           notify: true
           requires:
             - deploy-staging
+      - rollback-staging:
+          <<: *on_release_tag
+          type: approval
+          requires:
+            - deploy-staging
+      - finish-staging:
+          <<: *on_release_tag
+          requires:
+            - rollback-staging
 
 {{- if isTrue .Env.MAKE_MASTER }}
       - hold-production:
@@ -474,24 +517,11 @@ workflows:
       - deploy-production:
           <<: *on_release_tag
           notify: true
+          is_prod: true
           requires:
             - test-staging
             - hold-production
 {{- end }}
-{{- end }}
-
-{{- if isTrue .Env.MAKE_RELEASE }}
-  rollback-staging:
-    when:
-      equal: [ "rollback", << pipeline.parameters.release_stage >> ]
-    jobs:
-      - hold-rollback:
-          <<: *on_release_tag
-          type: approval
-      - rollback-staging:
-          <<: *on_release_tag
-          requires:
-            - hold-rollback
 {{- end }}
 
 {{- if isTrue .Env.MAKE_MASTER }}

--- a/templates/nro/.circleci/config.yml.tmpl
+++ b/templates/nro/.circleci/config.yml.tmpl
@@ -490,8 +490,10 @@ workflows:
       equal: [ "rollback", << pipeline.parameters.release_stage >> ]
     jobs:
       - hold-rollback:
+          <<: *on_release_tag
           type: approval
       - rollback-staging:
+          <<: *on_release_tag
           requires:
             - hold-rollback
 {{- end }}

--- a/templates/nro/.circleci/config.yml.tmpl
+++ b/templates/nro/.circleci/config.yml.tmpl
@@ -471,15 +471,11 @@ workflows:
           type: approval
           requires:
             - deploy-staging
-      - promote:
-          <<: *on_release_tag
-          requires:
-            - test-staging
-            - visualtests-compare
       - deploy-production:
           <<: *on_release_tag
           notify: true
           requires:
+            - test-staging
             - hold-production
 {{- end }}
 {{- end }}

--- a/templates/nro/.circleci/config.yml.tmpl
+++ b/templates/nro/.circleci/config.yml.tmpl
@@ -23,6 +23,8 @@ job_environments:
     WP_DB_NAME: {{ .Env.MYSQL_USERNAME }}_{{ .Env.MYSQL_DATABASE }}_develop
     WP_STATELESS_BUCKET: {{ .Env.CONTAINER_PREFIX }}-stateless-develop
 {{- if isTrue .Env.MAKE_RELEASE }}
+  release_build_env: &release_build_env
+    GOOGLE_PROJECT_ID: {{ .Env.GCP_PRODUCTION_PROJECT }}
   release_environment: &release_environment
     APP_ENVIRONMENT: staging
     APP_HOSTNAME: {{ .Env.RELEASE_HOSTNAME }}
@@ -114,10 +116,17 @@ job_definitions:
       - run: |
           if [[ -d source/cache ]]; then ls -al source/cache; fi
       - run: activate-gcloud-account.sh
-      - run: mkdir -p /tmp/workspace/var
-      - run: mkdir -p /tmp/workspace/src
+      - run: mkdir -p /tmp/workspace/var /tmp/workspace/src
       - run: echo "${CIRCLE_BUILD_NUM}" > /tmp/workspace/var/circle-build-num
-      - run: make
+      - run: make test
+      - run: make rewrite
+      - run: make checkout
+      - run: make rewrite-app-repos
+      - run: make copy
+      - run: make bake
+      - run: make persist
+      - run: make build
+      - run: make push
       - run:
           name: Notify failure
           when: on_fail
@@ -231,11 +240,11 @@ jobs:
       <<: *release_environment
     <<: *visualtests_compare_steps
 
-  build-staging:
+  build:
     <<: *defaults
     environment:
       <<: *common_environment
-      <<: *release_environment
+      <<: *release_build_env
     <<: *build_steps
 
   test-staging:
@@ -280,24 +289,6 @@ jobs:
       - run:
           name: Approve promotion
           command: promote-to-production.sh "${CIRCLE_WORKFLOW_ID}"
-
-  trigger-production:
-    <<: *defaults
-    environment:
-      <<: *common_environment
-    working_directory: /tmp/workspace/src
-    steps:
-      - checkout
-      - run:
-          name: Trigger production
-          command: trigger-production.sh "${CIRCLE_PROJECT_REPONAME}" "${CIRCLE_TAG}"
-
-  build-production:
-    <<: *defaults
-    environment:
-      <<: *common_environment
-      <<: *production_environment
-    <<: *build_steps
 
   deploy-production:
     <<: *defaults
@@ -402,22 +393,13 @@ jobs:
 {{- end }}
 
 workflow_definitions:
-  develop_common: &develop_common
+  on_develop_commit: &on_develop_commit
     context: org-global
     filters:
       branches:
         only: develop
 {{- if isTrue .Env.MAKE_RELEASE }}
-  staging_common: &staging_common
-    context: org-global
-    filters:
-      branches:
-        ignore: /.*/
-      tags:
-        only: /^v.*/
-{{- end }}
-{{- if isTrue .Env.MAKE_MASTER }}
-  production_common: &production_common
+  on_release_tag: &on_release_tag
     context: org-global
     filters:
       branches:
@@ -430,11 +412,11 @@ workflows:
   develop:
     jobs:
       - visualtests-reference-develop:
-          <<: *develop_common
+          <<: *on_develop_commit
       - build-develop:
-          <<: *develop_common
+          <<: *on_develop_commit
       - deploy-develop:
-          <<: *develop_common
+          <<: *on_develop_commit
           requires:
             - build-develop
             - visualtests-reference-develop
@@ -442,61 +424,61 @@ workflows:
             - merge-develop
 {{- end }}
       - test-develop:
-          <<: *develop_common
+          <<: *on_develop_commit
           requires:
             - deploy-develop
       - visualtests-compare-develop:
-          <<: *develop_common
+          <<: *on_develop_commit
           requires:
             - deploy-develop
 {{- if isTrue .Env.MAKE_RELEASE }}
       - merge-develop:
-          <<: *develop_common
+          <<: *on_develop_commit
 {{- else }}
       - data-sync:
-          <<: *develop_common
+          <<: *on_develop_commit
           requires:
             - deploy-develop
 {{- end }}
 
 {{- if isTrue .Env.MAKE_RELEASE }}
-  staging:
-    unless:
-      not:
-        equal: [ "staging", << pipeline.parameters.release_stage >> ]
+  release:
+    when:
+      equal: [ "release", << pipeline.parameters.release_stage >> ]
     jobs:
       - visualtests-reference:
-          <<: *staging_common
-      - build-staging:
-          <<: *staging_common
+          <<: *on_release_tag
+      - build:
+          <<: *on_release_tag
       - deploy-staging:
-          <<: *staging_common
+          <<: *on_release_tag
           requires:
-            - build-staging
+            - build
             - visualtests-reference
       - test-staging:
-          <<: *staging_common
+          <<: *on_release_tag
           requires:
             - deploy-staging
       - visualtests-compare:
-          <<: *staging_common
+          <<: *on_release_tag
           notify: true
           requires:
             - deploy-staging
 
 {{- if isTrue .Env.MAKE_MASTER }}
       - hold-production:
-          <<: *staging_common
+          <<: *on_release_tag
           type: approval
           requires:
-            - test-staging
+            - deploy-staging
       - promote:
-          <<: *staging_common
+          <<: *on_release_tag
           requires:
             - test-staging
             - visualtests-compare
-      - trigger-production:
-          <<: *staging_common
+      - deploy-production:
+          <<: *on_release_tag
+          notify: true
           requires:
             - hold-production
 {{- end }}
@@ -508,27 +490,13 @@ workflows:
       equal: [ "rollback", << pipeline.parameters.release_stage >> ]
     jobs:
       - hold-rollback:
-          <<: *staging_common
           type: approval
       - rollback-staging:
-          <<: *staging_common
           requires:
             - hold-rollback
 {{- end }}
 
 {{- if isTrue .Env.MAKE_MASTER }}
-  production:
-    when:
-      equal: [ "production", << pipeline.parameters.release_stage >> ]
-    jobs:
-      - build-production:
-          <<: *production_common
-      - deploy-production:
-          <<: *production_common
-          notify: true
-          requires:
-            - build-production
-
   sync-from-production:
     triggers:
       - schedule:


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5409

Example of generated config for cidev instance: https://github.com/greenpeace/planet4-cidev/compare/test-new-config?expand=1

* This image was already effictively the same in both workflows. They
used a different set of env vars, but the one it actually needed was
the same for stag and prod, the Google project id. So I created a new
set which only has that env var and the build just works.
* I kept the google project id in the stag and prod env var sets. This
avoids having to change a whole lot of config manually in all NRO repos.
* Merging stag and prod workflows turned out to be surprisingly simple.
In both, the deploy step was using an image tagged with the circleci
workflow run. So just moving the production jobs into the staging
workflow was enough to make it use the same image.
* Rename staging to release where appropriate.
* More specific names for workflows definitions.
* Make hold-production depend on deploy-staging, which makes the
pipeline fit into one screen.
