### PR TITLE
Remove Slack orb from visualtests-compare

### DIFF
--- a/templates/nro/.circleci/config.yml.tmpl
+++ b/templates/nro/.circleci/config.yml.tmpl
@@ -76,10 +76,6 @@ job_definitions:
       - image: greenpeaceinternational/planet4-backstop:latest
         auth: &docker_auth
     working_directory: /src
-    parameters:
-      notify:
-        type: boolean
-        default: false
     steps:
       - run: ./checkout.sh
       - run: ./mergescenarios.sh
@@ -89,14 +85,6 @@ job_definitions:
       - run: ./makecomparison.sh
       - store_artifacts:
           path: /app/backstop_data
-      - when:
-          condition: << parameters.notify >>
-          steps:
-            # Notify p4-activity-ci
-            - slack/status:
-                fail_only: true
-                channel: C015MQGG3KQ
-                webhook: ${SLACK_NRO_WEBHOOK}
 
   build_steps: &build_steps
     working_directory: ~/
@@ -520,7 +508,6 @@ workflows:
             - deploy-staging
       - visualtests-compare:
           <<: *on_release_tag
-          notify: true
           requires:
             - deploy-staging
       - rollback-staging:


### PR DESCRIPTION
Since we always pass that job, we never reach this step. We'll add a notification inside the job.

Related PR: greenpeace/planet4-backstop#7