### PR TITLE
Split deploy step

### DIFF
--- a/templates/nro/.circleci/config.yml.tmpl
+++ b/templates/nro/.circleci/config.yml.tmpl
@@ -177,7 +177,10 @@ job_definitions:
       - attach_workspace:
           at: /tmp/workspace
       - run: activate-gcloud-account.sh
-      - run: BUILD_TAG=build-$(cat /tmp/workspace/var/circle-build-num) make deploy
+      - run: make prepare-helm
+      - run: make backup
+      - run: BUILD_TAG=build-$(cat /tmp/workspace/var/circle-build-num) make deploy-helm
+      - run: make post-deploy
       - when:
           condition: << parameters.is_prod >>
           steps:


### PR DESCRIPTION
* This will give us grouped job output, as well as timing for each step.

It's also needed after we merge https://github.com/greenpeace/planet4-builder/pull/63/files, else backups won't run, as it was removed from the `deploy-helm` target.