### PR TITLE
PLANET-5685 Unhold jobs in other workflows

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN echo "deb http://packages.cloud.google.com/apt cloud-sdk-$(lsb_release -c -s
 RUN curl -sSo /app/bin/cloud_sql_proxy https://dl.google.com/cloudsql/cloud_sql_proxy.linux.amd64 && \
     chmod 755 /app/bin/cloud_sql_proxy
 
-RUN pip install yamllint==1.14.0
+RUN pip install --no-cache-dir yamllint==1.14.0
 
 WORKDIR /app
 

--- a/templates/nro/.circleci/config.yml.tmpl
+++ b/templates/nro/.circleci/config.yml.tmpl
@@ -53,6 +53,42 @@ job_environments:
     WP_STATELESS_BUCKET: {{ .Env.CONTAINER_PREFIX }}-stateless
 {{- end }}
 {{- end }}{{/* END if not .Env.IS_CONFIG_UPDATE */}}
+
+commands:
+  approve_job:
+    description: "Approve an on-hold job."
+    parameters:
+      job_name:
+        type: string
+    steps:
+      - run:
+          name: Unhold job "<< parameters.job_name >>"
+          command: |
+            if [ -f /tmp/workspace/approve_workflow ]; then
+              WORKFLOW_ID=$(cat /tmp/workspace/approve_workflow)
+              url="https://circleci.com/api/v2/workflow/$WORKFLOW_ID/job"
+
+              # Get workflow details
+              workflow=$(curl -s -u "${CIRCLE_TOKEN}": -X GET --header "Content-Type: application/json" "$url")
+              echo $workflow
+              # Get approval job id
+              job_id=$(echo "$workflow" | jq -r '.items[] | select(.name=="<< parameters.job_name >>") | .approval_request_id ')
+              echo $job_id
+
+              if [[ -z $job_id ]]; then
+                echo "Approval ID not found"
+                exit 1
+              fi
+
+              echo "Approving << parameters.job_name >> for workflow $url"
+              echo "Job ID: ${job_id}"
+              curl \
+                --header "Content-Type: application/json" \
+                -u "${CIRCLE_TOKEN}:" \
+                -X POST \
+                "https://circleci.com/api/v2/workflow/${CIRCLE_WORKFLOW_ID}/approve/${job_id}"
+            fi
+
 job_definitions:
   visualtests_reference_steps: &visualtests_reference_steps
     docker:
@@ -174,6 +210,8 @@ job_definitions:
         type: boolean
         default: false
     steps:
+      - checkout:
+          path: /home/circleci/checkout
       - attach_workspace:
           at: /tmp/workspace
       - run: activate-gcloud-account.sh
@@ -181,26 +219,24 @@ job_definitions:
       - run: make backup
       - run: BUILD_TAG=build-$(cat /tmp/workspace/var/circle-build-num) make deploy-helm
       - run: make post-deploy
+      - run:
+          name: Extract workflow from commit message
+          command: |
+            UNHOLD_WORKFLOW_LINE=$(git --git-dir=/home/circleci/checkout/.git log --format=%B -n 1 "$CIRCLE_SHA1" | { grep '^\/unhold ' || true; } )
+            echo "line $UNHOLD_WORKFLOW_LINE"
+            if [[ -n $UNHOLD_WORKFLOW_LINE ]]; then
+              WORKFLOW_ID=${UNHOLD_WORKFLOW_LINE#"/unhold "}
+              echo "$WORKFLOW_ID"
+              echo $WORKFLOW_ID > /tmp/workspace/approve_workflow
+            fi
+      - approve_job:
+          job_name: instance-ready
       - when:
           condition: << parameters.is_prod >>
           steps:
-            - run:
-                name: Initiate finish-staging (approve rollback but it won't really)
-                command: |
-                  url="https://circleci.com/api/v2/workflow/$CIRCLE_WORKFLOW_ID/job"
-
-                  # Get workflow details
-                  workflow=$(curl -s -u "${CIRCLE_TOKEN}": -X GET --header "Content-Type: application/json" "$url")
-                  # Get approval job id
-                  job_id=$(echo "$workflow" | jq -r '.items[] | select(.name=="rollback-staging") | .approval_request_id ')
-
-                  echo "Finishing staging."
-                  echo "Job ID: ${job_id}"
-                  curl \
-                    --header "Content-Type: application/json" \
-                    -u "${CIRCLE_TOKEN}:" \
-                    -X POST \
-                    "https://circleci.com/api/v2/workflow/${CIRCLE_WORKFLOW_ID}/approve/${job_id}"
+            - run: echo $CIRCLE_WORKFLOW_ID > /tmp/workspace/approve_workflow
+            - approve_job:
+                job_name: rollback-staging
       - when:
           condition: << parameters.notify >>
           steps:


### PR DESCRIPTION
* Extract job approval logic to a command. Requires to put a file in the
workspace, probably there's a better way to do this.
* Get the targetted workflow ID from a line starting with "/unhold " in
the commit message.

Tested on cidev instance https://app.circleci.com/pipelines/github/greenpeace/planet4-cidev/924/workflows/87e7f465-16e1-4de6-b2eb-9781203cec9f/jobs/2634

Ref: https://jira.greenpeace.org/browse/PLANET-5685

I guess we can add the logic inside the `approve_job` command to a script in [the builder repo](https://github.com/greenpeace/planet4-builder). Though I'm a bit hesitant for adding it there, as it would make (future) changes require 2 PRs. Also the builder image is already too big and needs to be split up, since any job using it spends about a minute just pulling and extracting the image. I'm checking for a better place to put it, suggestions welcome.