### PR TITLE
Enable nginx in stage and prod as default

### DIFF
--- a/templates/nro/.circleci/config.yml.tmpl
+++ b/templates/nro/.circleci/config.yml.tmpl
@@ -32,8 +32,6 @@ job_environments:
     HELM_RELEASE: {{ .Env.CONTAINER_PREFIX }}-release
     WP_DB_NAME: {{ .Env.MYSQL_USERNAME }}_{{ .Env.MYSQL_DATABASE }}_release
     WP_STATELESS_BUCKET: {{ .Env.CONTAINER_PREFIX }}-stateless-release
-    INGRESS_NOTLS: false
-    INGRESS_TLS: false
 {{- end }}
 {{- if isTrue .Env.MAKE_MASTER }}
   production_environment: &production_environment
@@ -50,8 +48,6 @@ job_environments:
     MIN_REPLICA_COUNT: 2
     WP_DB_NAME: {{ .Env.MYSQL_USERNAME }}_{{ .Env.MYSQL_DATABASE }}_master
     WP_STATELESS_BUCKET: {{ .Env.CONTAINER_PREFIX }}-stateless
-    INGRESS_NOTLS: false
-    INGRESS_TLS: false
 {{- end }}
 {{- end }}{{/* END if not .Env.IS_CONFIG_UPDATE */}}
 


### PR DESCRIPTION
NGINX is now our ingress controller so use the default chart parameters which have it enabled by default. This will prevent issues like with southasia not creating the correct ingress.