### PR TITLE
Separate namespaces for staging and development

### DIFF
--- a/templates/nro/.circleci/config.yml.tmpl
+++ b/templates/nro/.circleci/config.yml.tmpl
@@ -11,7 +11,11 @@ job_environments:
     CLOUDSQL_INSTANCE: {{ .Env.GCP_DEVELOPMENT_CLOUDSQL }}
     GOOGLE_PROJECT_ID: {{ .Env.GCP_DEVELOPMENT_PROJECT }}
     GCLOUD_CLUSTER: p4-development
+    {{- if .Env.APP_HOSTPATH }}
     HELM_NAMESPACE: {{ .Env.APP_HOSTPATH }}-development
+    {{- else }}
+    HELM_NAMESPACE: {{ replace .Env.CONTAINER_PREFIX "planet4-" "" 1 }}-development
+    {{- end }}
     HELM_RELEASE: {{ .Env.CONTAINER_PREFIX }}
     WP_DB_NAME: {{ .Env.MYSQL_USERNAME }}_{{ .Env.MYSQL_DATABASE }}_develop
     WP_STATELESS_BUCKET: {{ .Env.CONTAINER_PREFIX }}-stateless-develop
@@ -27,7 +31,7 @@ job_environments:
     {{- if .Env.APP_HOSTPATH }}
     HELM_NAMESPACE: {{ .Env.APP_HOSTPATH }}-staging
     {{- else }}
-    HELM_NAMESPACE: {{ replace .Env.CONTAINER_PREFIX "planet4-" "" 1 }}
+    HELM_NAMESPACE: {{ replace .Env.CONTAINER_PREFIX "planet4-" "" 1 }}-staging
     {{- end }}
     HELM_RELEASE: {{ .Env.CONTAINER_PREFIX }}-release
     WP_DB_NAME: {{ .Env.MYSQL_USERNAME }}_{{ .Env.MYSQL_DATABASE }}_release

--- a/templates/nro/.circleci/config.yml.tmpl
+++ b/templates/nro/.circleci/config.yml.tmpl
@@ -11,7 +11,7 @@ job_environments:
     CLOUDSQL_INSTANCE: {{ .Env.GCP_DEVELOPMENT_CLOUDSQL }}
     GOOGLE_PROJECT_ID: {{ .Env.GCP_DEVELOPMENT_PROJECT }}
     GCLOUD_CLUSTER: p4-development
-    HELM_NAMESPACE: develop
+    HELM_NAMESPACE: {{ .Env.APP_HOSTPATH }}-development
     HELM_RELEASE: {{ .Env.CONTAINER_PREFIX }}
     WP_DB_NAME: {{ .Env.MYSQL_USERNAME }}_{{ .Env.MYSQL_DATABASE }}_develop
     WP_STATELESS_BUCKET: {{ .Env.CONTAINER_PREFIX }}-stateless-develop
@@ -25,7 +25,7 @@ job_environments:
     GCLOUD_CLUSTER: {{ .Env.GCP_PRODUCTION_CLUSTER }}
     GOOGLE_PROJECT_ID: {{ .Env.GCP_PRODUCTION_PROJECT }}
     {{- if .Env.APP_HOSTPATH }}
-    HELM_NAMESPACE: {{ .Env.APP_HOSTPATH }}
+    HELM_NAMESPACE: {{ .Env.APP_HOSTPATH }}-staging
     {{- else }}
     HELM_NAMESPACE: {{ replace .Env.CONTAINER_PREFIX "planet4-" "" 1 }}
     {{- end }}


### PR DESCRIPTION
# Separate namespaces for staging and development

This PR brings development and staging in line with production (separate namespaces for resources) this bring production and development closer together making testing changes easier.

Modification to builder required that will delete the ingress if namespace = (in dev "develop", in staging "<same as prod>", in prod "<nothing>")

Then delete the develop namespace and the staging deployments. We can use the "environment" label to do this.