### PR TITLE
PLANET-7064: Add test user jobs

### DIFF
--- a/templates/nro/.circleci/config-header.yml.tmpl
+++ b/templates/nro/.circleci/config-header.yml.tmpl
@@ -6,6 +6,25 @@ parameters:
     type: boolean
     default: false
 
+  run_develop:
+    default: true
+    type: boolean
+
+{{- if isTrue .Env.MAKE_RELEASE }}
+{{- else }}
+  run_create_test_user:
+    default: false
+    type: boolean
+
+  run_delete_test_user:
+    default: false
+    type: boolean
+
+  unhold:
+    default: ""
+    type: string
+{{- end }}
+
 docker_auth: &docker_auth
   username: $DOCKERHUB_USERNAME
   password: $DOCKERHUB_PASSWORD

--- a/templates/nro/.circleci/config.yml.tmpl
+++ b/templates/nro/.circleci/config.yml.tmpl
@@ -216,6 +216,59 @@ jobs:
     <<: *deploy_steps
 
 {{- if isTrue .Env.MAKE_RELEASE }}
+{{- else }}
+  create-test-user:
+    working_directory: ~/
+    docker:
+      - image: greenpeaceinternational/p4-builder:latest
+        auth:
+          <<: *docker_auth
+    environment:
+      <<: *common_environment
+      <<: *develop_environment
+      WORKFLOW_ID: << pipeline.parameters.unhold >>
+    steps:
+      - checkout:
+          path: /home/circleci/checkout
+      - attach_workspace:
+          at: /tmp/workspace
+      - run: activate-gcloud-account.sh
+      - run: make prepare-helm
+      - run:
+          name: Create test user
+          command: /home/circleci/bin/test_account_add.sh
+      - run:
+          name: Unhold e2e test job
+          command: |
+            if [[ -n $WORKFLOW_ID ]]; then
+              echo "$WORKFLOW_ID"
+              echo $WORKFLOW_ID > /tmp/workspace/approve_workflow
+            fi
+      - approve_job:
+          job_name: test-user-ready
+
+  delete-test-user:
+    working_directory: ~/
+    docker:
+      - image: greenpeaceinternational/p4-builder:latest
+        auth:
+          <<: *docker_auth
+    environment:
+      <<: *common_environment
+      <<: *develop_environment
+    steps:
+      - checkout:
+          path: /home/circleci/checkout
+      - attach_workspace:
+          at: /tmp/workspace
+      - run: activate-gcloud-account.sh
+      - run: make prepare-helm
+      - run:
+          name: Delete test user
+          command: /home/circleci/bin/test_account_remove.sh
+{{- end }}
+
+{{- if isTrue .Env.MAKE_RELEASE }}
 
   visualtests-reference:
     environment:
@@ -464,6 +517,7 @@ workflow_definitions:
 
 workflows:
   develop:
+    when: << pipeline.parameters.run_develop >>
     jobs:
       - build-develop:
           <<: *on_develop_commit
@@ -472,6 +526,21 @@ workflows:
           requires:
             - build-develop
 
+{{- if isTrue .Env.MAKE_RELEASE }}
+{{- else }}
+  create-test-user:
+    when: << pipeline.parameters.run_create_test_user >>
+    jobs:
+      - create-test-user:
+          context: org-global
+
+  delete-test-user:
+    when: << pipeline.parameters.run_delete_test_user >>
+    jobs:
+      - delete-test-user:
+          context: org-global
+
+{{- end }}
 {{- if isTrue .Env.MAKE_RELEASE }}
   production:
     unless: << pipeline.parameters.rollback >>


### PR DESCRIPTION
Related to: https://github.com/greenpeace/planet4-master-theme/pull/1925
Cf. https://support.circleci.com/hc/en-us/articles/360050351292-How-to-trigger-a-workflow-via-CircleCI-API-v2

Create and delete test user on demand.